### PR TITLE
Detailed and CSV Output + 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 bin
 deps/
 .vs/
+vc140.pdb

--- a/src/main.c
+++ b/src/main.c
@@ -154,14 +154,14 @@ ecs_time_t ecs_time_add(
     if (result.nanosec >= 1000000000) {
         uint32_t s = result.nanosec / 1000000000;
         result.nanosec -= s * 1000000000;
-        result.sec = s;
+        result.sec += s;
     }
 
     return result;
 }
 
 uint64_t ecs_time_to_nanos(ecs_time_t t) {
-    return t.sec * 1000000000 + t.nanosec;
+    return (uint64_t)t.sec * (uint64_t)1000000000 + (uint64_t)t.nanosec;
 }
 
 bool bench_next(bench_t *b) {


### PR DESCRIPTION
I ended up getting a little distracted and spent a bit more time on some other improvements 😄

## Change Log
- Replaced `PRETTY_TIME_FMT` with `bench_result_format_t`
  - Added `--csv` command line argument
  - Added `--detailed` command line argument
- Improved output formatting
  - Removed `(int)(36 - strlen(label))` to instead use padding with printf (eg. `%36s`)
  - Removed `spacing(float v)` and instead pad using printf (eg. `%10.3f`)
- Replaced `WARMUP_INTERVALS` with `WARMUP_INTERVAL` by using it as the initial value for `bench_t::interval`, this reduces the number of branches in `bench_next(bench_t*)`.
- Removed `double dt` from `bench_t` and instead store `ecs_time_t start, stop, total` and changed `bench_next(bench_t*)` to start and stop for every sample, and accumulate the total for each sample to remove measurement overhead.
- Renamed `bench_t::intervals` to `bench_t::samples`
- Added `do_not_optimize(uint32_t)`
  This replaces usages of:
  ```c
  printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b", 
        (uint32_t)result);
  ```
  Also changed it to output to `stderr` instead of `stdout` so it doesn't interfere when you do `./ecs_benchmark --csv --detailed > results.csv`
- Use the warmup time to calculate an appropriate interval to help reduce the overhead on fast benchmarks

## Output Format
Output now has 4 different options.

<details> 
  <summary>Human Readable (Default)</summary>

![image](https://github.com/SanderMertens/ecs_benchmark/assets/1109304/74d17f8a-4418-4eb0-b6f3-151915f55d5f)
```md
| Benchmark                             | Measurement  |
|---------------------------------------|--------------|
| baseline                              |      1.866ns |
| world_mini_fini                       |    699.110us |
| world_init_fini                       |      1.982ms |
| has_empty_entity                      |      2.218ns |
| has_id_not_found                      |      5.668ns |
| has_id                                |      6.543ns |
| has_16_ids                            |      6.787ns |
| get_empty_entity                      |      0.002ns |
| get_id_not_found                      |      0.002ns |
| get_id                                |      0.002ns |
| get_16_ids                            |      0.000ns |
| get_pair                              |      0.002ns |
| get_pair_16_targets                   |      0.000ns |
...
```
</details>
<details> 
  <summary>Human Readable Detailed</summary>

![image](https://github.com/SanderMertens/ecs_benchmark/assets/1109304/8693098e-c749-49ec-85c9-936ad95d0b5f)

```md
| Benchmark                             | Measurement  | Total (ns)   | Count          | Samples      |
|---------------------------------------|--------------|--------------|----------------|--------------|
| baseline                              |      1.844ns |   1000000100 |      542402100 |     10848042 |
| world_mini_fini                       |    717.889us |   1005044900 |           1400 |           28 |
| world_init_fini                       |      1.986ms |   1092249400 |            550 |           11 |
| has_empty_entity                      |      2.129ns |   1000031200 |      469650000 |         9393 |
| has_id_not_found                      |      5.622ns |   1000217700 |      177900000 |         3558 |
| has_id                                |      6.414ns |   1000257500 |      155950000 |         3119 |
| has_16_ids                            |      6.584ns |   1000778800 |      152000000 |          190 |
| get_empty_entity                      |      0.002ns |   1000000100 |   517687300000 |     10353746 |
| get_id_not_found                      |      0.002ns |   1000000100 |   572414600000 |     11448292 |
| get_id                                |      0.002ns |   1000000100 |   566892550000 |     11337851 |
| get_16_ids                            |      0.000ns |   1000000100 |  9136676000000 |     11420845 |
| get_pair                              |      0.002ns |   1000000100 |   526970050000 |     10539401 |
| get_pair_16_targets                   |      0.000ns |   1000000100 |  8464068800000 |     10580086 |
| get_inherited_depth_1                 |      0.002ns |   1000000100 |   572209650000 |     11444193 |
| get_inherited_depth_2                 |      0.002ns |   1000000100 |   571049300000 |     11420986 |
| get_inherited_depth_16                |      0.002ns |   1000000100 |   529902650000 |     10598053 |
...
```
</details>
<details> 
  <summary>CSV</summary>

```csv
Benchmark,Measurement (ns)
baseline,1.896159
world_mini_fini,716582.357143
world_init_fini,1856217.454545
has_empty_entity,2.176629
has_id_not_found,5.602006
has_id,6.436829
has_16_ids,6.596657
get_empty_entity,0.001925
get_id_not_found,0.001751
get_id,0.001756
...
```
</details>
<details> 
  <summary>CSV Detailed</summary>

```csv
Benchmark,Measurement (ns),Total (ns),Count,Samples
baseline,1.865273,1000000100,536114500,10722290
world_mini_fini,753041.111111,1016605500,1350,27
world_init_fini,1973357.090909,1085346400,550,11
has_empty_entity,2.130968,1000063100,469300000,9386
has_id_not_found,5.588571,1000074700,178950000,3579
has_id,6.418141,1000267300,155850000,3117
has_16_ids,6.551260,1001032600,152800000,191
get_empty_entity,0.001891,1000000100,528785450000,10575709
get_id_not_found,0.001781,1000000100,561582750000,11231655
get_id,0.001764,1000000100,566837900000,11336758
get_16_ids,0.000109,1000000100,9145068000000,11431335
get_pair,0.001926,1000001400,519112600000,10382252
...
```
</details>