### PR TITLE
Fix measurement + prevent some compiler optimizations

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -165,7 +165,7 @@ bool bench_next(bench_t *b) {
 }
 
 void bench_end(bench_t *b) {
-    bench_print(b->lbl, b->dt / ((b->intervals - WARMUP_INTERVALS) * MEASURE_INTERVAL * b->count));
+    bench_print(b->lbl, b->dt / (((uint64_t)b->intervals - 1) * MEASURE_INTERVAL * (uint64_t)b->count));
 }
 
 /* -- benchmark code -- */

--- a/src/main.c
+++ b/src/main.c
@@ -205,10 +205,15 @@ ecs_entity_t* create_ids(ecs_world_t *world, int32_t count, ecs_size_t size, boo
 }
 
 void baseline(void) {
+    uint32_t result = 0;
+    
     bench_t b = bench_begin("baseline", 1);
     do {
+        result++;
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 }
 
 void world_mini_fini(void) {
@@ -377,14 +382,18 @@ void has_empty_entity(void) {
     ecs_world_t *world = ecs_mini();
     ecs_entity_t *entities = create_ids(world, ENTITY_COUNT, 0, false);
     ecs_entity_t *ids = create_ids(world, 1, 0, true);
+
+    uint32_t result = 0;
     
     bench_t b = bench_begin("has_empty_entity", ENTITY_COUNT);
     do {
         for (int e = 0; e < ENTITY_COUNT; e ++) {
-            ecs_has_id(world, entities[e], ids[0]);
+            result += ecs_has_id(world, entities[e], ids[0]);
         }
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 
     ecs_fini(world);
     ecs_os_free(entities);
@@ -400,13 +409,17 @@ void has_id_not_found(void) {
         ecs_add_id(world, entities[e], ids[0]);
     }
 
+    uint32_t result = 0;
+
     bench_t b = bench_begin("has_id_not_found", ENTITY_COUNT);
     do {
         for (int e = 0; e < ENTITY_COUNT; e ++) {
-            ecs_has_id(world, entities[e], ids[1]);
+            result += ecs_has_id(world, entities[e], ids[1]);
         }
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 
     ecs_fini(world);
     ecs_os_free(entities);
@@ -424,15 +437,19 @@ void has_id(const char *label, int32_t id_count) {
         }
     }
 
+    uint32_t result = 0;
+
     bench_t b = bench_begin(label, ENTITY_COUNT * id_count);
     do {
         for (int e = 0; e < ENTITY_COUNT; e ++) {
             for (int i = 0; i < id_count; i ++) {
-                ecs_has_id(world, entities[e], ids[i]);
+                result += ecs_has_id(world, entities[e], ids[i]);
             }
         }
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 
     ecs_fini(world);
     ecs_os_free(entities);
@@ -443,14 +460,18 @@ void get_empty_entity(void) {
     ecs_world_t *world = ecs_mini();
     ecs_entity_t *entities = create_ids(world, ENTITY_COUNT, 0, false);
     ecs_entity_t *ids = create_ids(world, 1, 4, true);
+
+    uintptr_t result = 0;
     
     bench_t b = bench_begin("get_empty_entity", ENTITY_COUNT);
     do {
         for (int e = 0; e < ENTITY_COUNT; e ++) {
-            ecs_get_id(world, entities[e], ids[0]);
+            result += (uintptr_t)ecs_get_id(world, entities[e], ids[0]);
         }
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 
     ecs_fini(world);
     ecs_os_free(entities);
@@ -465,14 +486,18 @@ void get_id_not_found(void) {
     for (int e = 0; e < ENTITY_COUNT; e ++) {
         ecs_add_id(world, entities[e], ids[0]);
     }
+
+    uintptr_t result = 0;
     
     bench_t b = bench_begin("get_id_not_found", ENTITY_COUNT);
     do {
         for (int e = 0; e < ENTITY_COUNT; e ++) {
-            ecs_get_id(world, entities[e], ids[1]);
+            result += (uintptr_t)ecs_get_id(world, entities[e], ids[1]);
         }
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 
     ecs_fini(world);
     ecs_os_free(entities);
@@ -490,15 +515,19 @@ void get_id(const char *label, int32_t id_count) {
         }
     }
 
+    uintptr_t result = 0;
+
     bench_t b = bench_begin(label, ENTITY_COUNT * id_count);
     do {
         for (int e = 0; e < ENTITY_COUNT; e ++) {
             for (int i = 0; i < id_count; i ++) {
-                ecs_get_id(world, entities[e], ids[i]);
+                result += (uintptr_t)ecs_get_id(world, entities[e], ids[i]);
             }
         }
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 
     ecs_fini(world);
     ecs_os_free(entities);
@@ -516,15 +545,19 @@ void get_mut_id(const char *label, int32_t id_count) {
         }
     }
 
+    uintptr_t result = 0;
+
     bench_t b = bench_begin(label, ENTITY_COUNT * id_count);
     do {
         for (int e = 0; e < ENTITY_COUNT; e ++) {
             for (int i = 0; i < id_count; i ++) {
-                ecs_get_mut_id(world, entities[e], ids[i]);
+                result += (uintptr_t)ecs_get_mut_id(world, entities[e], ids[i]);
             }
         }
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 
     ecs_fini(world);
     ecs_os_free(entities);
@@ -536,11 +569,13 @@ void get_mut_remove(const char* label, int32_t id_count) {
     ecs_entity_t *entities = create_ids(world, ENTITY_COUNT, 0, false);
     ecs_entity_t *ids = create_ids(world, id_count, 4, true);
 
+    uintptr_t result = 0;
+
     bench_t b = bench_begin(label, 2 * ENTITY_COUNT * id_count);
     do {
         for (int e = 0; e < ENTITY_COUNT; e ++) {
             for (int i = 0; i < id_count; i ++) {
-                ecs_get_mut_id(world, entities[e], ids[i]);
+                result += (uintptr_t)ecs_get_mut_id(world, entities[e], ids[i]);
             }
             for (int i = 0; i < id_count; i ++) {
                 ecs_remove_id(world, entities[e], ids[i]);
@@ -548,6 +583,8 @@ void get_mut_remove(const char* label, int32_t id_count) {
         }
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 
     ecs_fini(world);
     ecs_os_free(entities);
@@ -594,15 +631,19 @@ void get_pair(const char *label, int32_t target_count) {
         }
     }
 
+    uintptr_t result = 0;
+
     bench_t b = bench_begin(label, ENTITY_COUNT * target_count);
     do {
         for (int e = 0; e < ENTITY_COUNT; e ++) {
             for (int i = 0; i < target_count; i ++) {
-                ecs_get_id(world, entities[e], ecs_pair(rel[0], tgt[i]));
+                result += (uintptr_t)ecs_get_id(world, entities[e], ecs_pair(rel[0], tgt[i]));
             }
         }
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 
     ecs_fini(world);
     ecs_os_free(rel);
@@ -623,13 +664,17 @@ void get_inherited(const char *label, int32_t depth) {
         ecs_add_pair(world, entities[e], EcsIsA, base);
     }
 
+    uintptr_t result = 0;
+
     bench_t b = bench_begin(label, ENTITY_COUNT);
     do {
         for (int e = 0; e < ENTITY_COUNT; e ++) {
-            ecs_get_id(world, entities[e], id);
+            result += (uintptr_t)ecs_get_id(world, entities[e], id);
         }
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 
     ecs_fini(world);
 }
@@ -643,13 +688,18 @@ void ref_init(void) {
         ecs_add_id(world, entities[e], ids[0]);
     }
 
+    uintptr_t result = 0;
+
     bench_t b = bench_begin("ref_init", ENTITY_COUNT);
     do {
         for (int e = 0; e < ENTITY_COUNT; e ++) {
-            ecs_ref_init_id(world, entities[e], ids[0]);
+            ecs_ref_t ref = ecs_ref_init_id(world, entities[e], ids[0]);
+            result += (uintptr_t)ref.tr;
         }
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 
     ecs_fini(world);
     ecs_os_free(entities);
@@ -666,14 +716,18 @@ void ref_get(void) {
         ecs_add_id(world, entities[e], ids[0]);
         refs[e] = ecs_ref_init_id(world, entities[e], ids[0]);
     }
+
+    uintptr_t result = 0;
     
     bench_t b = bench_begin("ref_get", ENTITY_COUNT);
     do {
         for (int e = 0; e < ENTITY_COUNT; e ++) {
-            ecs_ref_get_id(world, &refs[e], ids[0]);
+            result += (uintptr_t)ecs_ref_get_id(world, &refs[e], ids[0]);
         }
     } while (bench_next(&b));
     bench_end(&b);
+
+    do_not_optimize(result);
 
     ecs_fini(world);
     ecs_os_free(entities);

--- a/src/main.c
+++ b/src/main.c
@@ -2,8 +2,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define WARMUP_INTERVALS (5)
+// The number of times to run the benchmark before starting to record.
+#define WARMUP_INTERVAL (200)
+// The frequency at which to take a measurement.
 #define MEASURE_INTERVAL (50)
+// The minimum amount of time a benchmark must have run for.
 #define MEASURE_TIME (0.5)
 
 #define PRETTY_TIME_FMT
@@ -133,7 +136,7 @@ void bench_print(const char *label, float v) {
 bench_t bench_begin(const char *lbl, int32_t count) {
     bench_t b = {0};
     b.lbl = lbl;
-    b.interval = MEASURE_INTERVAL;
+    b.interval = WARMUP_INTERVAL;
     b.intervals = 0;
     b.count = count;
     return b;
@@ -149,14 +152,15 @@ double time_measure(
 
 bool bench_next(bench_t *b) {
     if (!--b->interval) {
-        b->intervals ++;
-        if (b->intervals > WARMUP_INTERVALS) {
+        // `intervals == 0` means we are doing warmup
+        // When `intervals > 0` take a measurement
+        if (b->intervals++) {
             double dt = time_measure(&b->t);
             if (dt > MEASURE_TIME) {
                 b->dt = dt;
                 return false;
             }
-        } else if (b->intervals == WARMUP_INTERVALS) {
+        } else {
             ecs_os_get_time(&b->t);
         }
         b->interval = MEASURE_INTERVAL;

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
 #include <ecs_benchmark.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -110,6 +111,10 @@ char* bench_asprintf(
     char *result = bench_vasprintf(fmt, args);
     va_end(args);
     return result;
+}
+
+void do_not_optimize(uint64_t v) {
+    fprintf(stderr, "result = %" PRId64 "\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b", v);
 }
 
 #ifdef PRETTY_TIME_FMT
@@ -1339,8 +1344,7 @@ void filter_simple_iter(const char *label, int32_t query_count, bool component, 
     } while (bench_next(&b));
     bench_end(&b);
 
-    printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b", 
-        (uint32_t)result);
+    do_not_optimize(result);
 
     ecs_filter_fini(q);
     ecs_fini(world);
@@ -1379,8 +1383,7 @@ void filter_iter(const char *label, int32_t id_count, bool component, int32_t qu
     } while (bench_next(&b));
     bench_end(&b);
 
-    printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b",
-        result);
+    do_not_optimize(result);
 
     ecs_filter_fini(f);
     ecs_fini(world);
@@ -1429,8 +1432,7 @@ void filter_iter_up(const char *label, bool component, bool query_self) {
     } while (bench_next(&b));
     bench_end(&b);
 
-    printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b",
-        result);
+    do_not_optimize(result);
 
     ecs_filter_fini(f);
     ecs_fini(world);
@@ -1482,8 +1484,7 @@ void filter_iter_up_w_mut(const char *label, bool component, bool query_self) {
     } while (bench_next(&b));
     bench_end(&b);
 
-    printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b",
-        result);
+    do_not_optimize(result);
 
     ecs_filter_fini(f);
     ecs_fini(world);
@@ -1541,8 +1542,7 @@ void rule_simple_iter(const char *label, int32_t query_count, bool component, ec
     } while (bench_next(&b));
     bench_end(&b);
 
-    printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b", 
-        (uint32_t)result);
+    do_not_optimize(result);
 
     ecs_rule_fini(q);
     ecs_fini(world);
@@ -1581,8 +1581,7 @@ void rule_iter(const char *label, int32_t id_count, bool component, int32_t quer
     } while (bench_next(&b));
     bench_end(&b);
 
-    printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b",
-        result);
+    do_not_optimize(result);
 
     ecs_rule_fini(f);
     ecs_fini(world);
@@ -1625,8 +1624,7 @@ void rule_inheritance(const char *label, int32_t depth, int32_t id_count) {
     } while (bench_next(&b));
     bench_end(&b);
 
-    printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b",
-        result);
+    do_not_optimize(result);
 
     ecs_rule_fini(f);
     ecs_fini(world);
@@ -1691,8 +1689,7 @@ void query_iter(const char *label, int32_t table_count, int32_t term_count, bool
     } while (bench_next(&b));
     bench_end(&b);
 
-    printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b", 
-        (uint32_t)result);
+    do_not_optimize(result);
 
     ecs_query_fini(q);
     ecs_fini(world);
@@ -1736,8 +1733,7 @@ void query_iter_empty(const char *label, int32_t table_count) {
     } while (bench_next(&b));
     bench_end(&b);
 
-    printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b", 
-        (uint32_t)result);
+    do_not_optimize(result);
 
     ecs_query_fini(q);
     ecs_fini(world);
@@ -1775,8 +1771,7 @@ void query_iter_rnd(const char *label, int32_t id_count) {
     } while (bench_next(&b));
     bench_end(&b);
 
-    printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b", 
-        (uint32_t)result);
+    do_not_optimize(result);
 
     ecs_query_fini(q);
     ecs_fini(world);
@@ -1810,8 +1805,7 @@ void query_count(const char *label, int32_t table_count) {
     } while (bench_next(&b));
     bench_end(&b);
 
-    printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b", 
-        (uint32_t)result);
+    do_not_optimize(result);
 
     ecs_query_fini(q);
     ecs_fini(world);


### PR DESCRIPTION
## Change Log
- Fixed `bench_end`
  ```c
  b->dt / ((b->intervals - WARMUP_INTERVALS) * MEASURE_INTERVAL * b->count)
  ```
  Its possible for the total count to be a value larger than a 32-bit unsigned integer can hold and since `b->intervals` and `b->count` are `uint32_t`, and `WARMUP_INTERVALS` and `MEASURE_INTERVAL` are unspecified integers the result will be computed to a `uint32_t`.
  The fix is to cast `b->intervals` to a `uint64_t` to ensure we don't overflow.
- Changed the warmup to just be the first interval rather than a number of intervals.
- Added `do_not_optimize(uint32_t)`
  This replaces usages of:
  ```c
  printf("result = %u\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b", 
        result);
  ```
  Also changed it to output to stderr instead of stdout so you can pipe the results to a file or another application.
- Added `do_not_optimize(uint32_t)` usage to benchmarks that had the possibility of being optimized away by some compilers.